### PR TITLE
Be able to produce metrics for BAM files with dots in their names

### DIFF
--- a/bamMetrics.brew
+++ b/bamMetrics.brew
@@ -2,6 +2,7 @@
 
 \usepackage[margin=1cm,nohead]{geometry}
 \usepackage[pdftex]{graphicx}
+\usepackage{grffile}
 \usepackage{subfig}
 \usepackage{float}
 \usepackage{pdflscape}

--- a/parseFlagstatOutput.pl
+++ b/parseFlagstatOutput.pl
@@ -30,15 +30,15 @@ print "Parsing flagstat files \n";
 foreach my $file (@flagstat_files) {
     print "\t Parsing: ". $file . "\n";
     open(FILE, $file) || die ("Can't open $file");
-    
+
     my ($sample) = ($file =~ m/.+\/(.+).flagstat/);
     push(@samples, $sample);
     while (my $line = <FILE>){
-	if ($. == 1 ) {
+	if ($. == 1) {
 	    my $total_reads = (split(' ',$line))[0];
 	    push(@read_counts, $total_reads);
 	}
-	if ($. == 5 ) { 
+	if ($. == 5) {
 	    my ($mapped_percentage) = $line =~ /(\d{2}\.\d{2}\%)/;
 	    push(@mapped_percentages, $mapped_percentage);
 	}
@@ -56,6 +56,6 @@ __END__
 
 =head1 SYNOPSIS
 
-$ perl parsePicardOutput.pl -output_dir /path/to/output -flagstat <my_file.flagstat>
+$ perl parseFlagstatOutput.pl -output_dir /path/to/output -flagstat <my_file.flagstat>
 
 =cut


### PR DESCRIPTION
The `grffile` LaTeX package appears to be available as standard in TeX
Live and provides more flexible file name handling to the graphicx
package. In particular, this allows BAM files to contain dots in their
names.

Also tidy up some whitespace and usage information for the new flagstat
parser.