### PR TITLE
Be careful not to drop row names when slicing

### DIFF
--- a/bamMetrics.R
+++ b/bamMetrics.R
@@ -42,7 +42,7 @@ if (file.exists(fileName)){
   #Transpose and write summaryTable
   summaryTableT = t(summaryTable)
   colnames(summaryTableT) = summaryTableT[1,]
-  summaryTableT = rbind(flagstatTable, summaryTableT[c(4:(nrow(summaryTableT)-3)),])
+  summaryTableT = rbind(flagstatTable, summaryTableT[c(4:(nrow(summaryTableT)-3)), , drop=FALSE])
   write.table(summaryTableT, file="HSMetrics_summary.transposed.txt", col.names=NA, na="", quote=FALSE, sep="\t")
   
   pdfOut =  paste(output_dir,"pdfFigures", sep="/")
@@ -68,7 +68,7 @@ if (file.exists(fileName)){
   #Transpose and write summaryTable
   summaryTableT = t(summaryTable)
   colnames(summaryTableT) = summaryTableT[1,]
-  summaryTableT = rbind(flagstatTable, summaryTableT[c(2:(nrow(summaryTableT))),])
+  summaryTableT = rbind(flagstatTable, summaryTableT[c(2:(nrow(summaryTableT))), , drop=FALSE])
   write.table(summaryTableT, file="WGSMetrics_summary.transposed.txt", col.names=NA, na="", quote=FALSE, sep="\t")
 }
 
@@ -83,7 +83,7 @@ if (file.exists(fileName)){
   #Transpose and write summaryTable
   summaryTableT = t(summaryTable)
   colnames(summaryTableT) = summaryTableT[1,]
-  summaryTableT = rbind(flagstatTable, summaryTableT[c(2:(nrow(summaryTableT))),])
+  summaryTableT = rbind(flagstatTable, summaryTableT[c(2:(nrow(summaryTableT))), , drop=FALSE])
   write.table(summaryTableT, file="RNAMetrics_summary.transposed.txt", col.names=NA, na="", quote=FALSE, sep="\t")
 }
 

--- a/bamMetrics_include.R
+++ b/bamMetrics_include.R
@@ -142,7 +142,7 @@ include_tbl <- function(tableName) {
   splitTableN = floor(75/colNameMean)  
   splitTable = split(1:colNumber, rep(1:colNumber,each=splitTableN,length=colNumber))
   for (i in 1:length(splitTable)){
-    tempTable = as.matrix(tableName[, unlist(splitTable[i],use.names=F)])
+    tempTable = as.matrix(tableName[, unlist(splitTable[i],use.names=F), drop=FALSE])
     colnames(tempTable) = colnames(tableName)[unlist(splitTable[i],use.names=F)]
     print(xtable(tempTable), type="latex",table.placement = "H")
   }


### PR DESCRIPTION
Recent changes to use `rbind` of the flagstats and a slice of the transposed summary require care to to drop row names (/dimension), since they form part of the output. Without this, the single-sample case results in weird output due to dropping dimension/names:

```
    GIAB12878-neoprep_dedup
Total number of reads   812061916
Percentage reads mapped 98.58%
3   2858674662
```
