### PR TITLE
Replace deprecated POSIX::tmpnam() with File::Temp::tmpnam().

### DIFF
--- a/bamMetrics.pl
+++ b/bamMetrics.pl
@@ -7,9 +7,9 @@ use strict;
 use warnings;
 use Getopt::Long;
 use Pod::Usage;
-use POSIX qw(tmpnam);
+use File::Temp qw/ :POSIX /;
 use Cwd qw(cwd abs_path);
-use File::Basename qw( dirname );
+use File::Basename qw( dirname fileparse );
 use File::Copy;
 
 ### Input options ###
@@ -426,7 +426,7 @@ sub bashAndSubmit {
 
 sub get_job_id {
     my $id = tmpnam();
-    $id =~ s/\/tmp\/file//;
+    $id = fileparse($id);
     return $id;
 }
 


### PR DESCRIPTION
The assumption that tmpnam() creates a file as /tmp/file<random> no longer
holds.  Therefore, we need to replace the regexp for something else.  I used
File::Basename::fileparse() as a replacement.